### PR TITLE
feat: created custom select component for priority selection

### DIFF
--- a/src/components/shared/CustomSelect.tsx
+++ b/src/components/shared/CustomSelect.tsx
@@ -1,0 +1,133 @@
+import { cn } from "@/lib/utils";
+import { OptionType, Priority } from "@/types/taskType";
+import React, { FC } from "react";
+import { createPortal } from "react-dom";
+
+interface CustomSelectProps extends React.ComponentPropsWithoutRef<"div"> {
+  defaultValue: string;
+  optionStyles?: string;
+  icon?: React.ReactElement;
+  className?: string | undefined;
+  options?: OptionType[];
+  onChange: (value: unknown) => void;
+}
+
+const optionDotVariant = {
+  [Priority.Low]: "bg-green-500",
+  [Priority.Medium]: "bg-yellow-500",
+  [Priority.High]: "bg-red-500",
+};
+
+export const CustomSelect: FC<CustomSelectProps> = ({
+  defaultValue,
+  options,
+  onChange,
+  optionStyles,
+  icon,
+  className,
+  ...props
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [position, setPosition] = React.useState({ top: 0, left: 0, width: 0 });
+  React.useEffect(() => {
+    if (!ref || typeof ref === "function") return;
+
+    const handleClick = (event: MouseEvent) => {
+      const { target } = event;
+      if (target instanceof Node && !ref?.current?.contains(target)) {
+        setIsOpen(false);
+      }
+    };
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setPosition({
+        top: rect.bottom + window.scrollY + 5,
+        left: rect.left + window.scrollX,
+        width: rect.width,
+      });
+    }
+
+    window.addEventListener("click", handleClick);
+
+    return () => {
+      window.removeEventListener("click", handleClick);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (isOpen && ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setPosition({
+        top: rect.bottom + window.scrollY + 5,
+        left: rect.left + window.scrollX,
+        width: rect.width,
+      });
+    }
+  }, [isOpen]);
+  return (
+    <div
+      onClick={() => setIsOpen(!isOpen)}
+      ref={ref}
+      {...props}
+      className={cn(
+        "p-2 rounded border border-slate-800 flex justify-between relative select-none",
+        className
+      )}
+    >
+      {defaultValue}
+      <div
+        className={cn(
+          "transition-transform duration-300",
+          isOpen ? "-rotate-180" : "rotate-0"
+        )}
+      >
+        {icon}
+      </div>
+      {createPortal(
+        <ul
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "absolute flex flex-col gap-1 left-0 top-[110%] w-full select-none z-50 transition-all duration-300 ",
+            optionStyles,
+            isOpen ? "visible" : "invisible "
+          )}
+          style={{
+            position: "absolute",
+            top: `${position.top}px`,
+            left: `${position.left}px`,
+            width: `${position.width}px`,
+          }}
+        >
+          {options?.map((option, index) => (
+            <li
+              key={option.value}
+              onClick={() => {
+                onChange(option.value);
+                setIsOpen(false);
+              }}
+              className={cn(
+                "p-2 border border-slate-800 rounded bg-white hover:shadow-md transition-all duration-300 hover:transition-none flex justify-between items-center",
+                isOpen
+                  ? `translate-y-0 opacity-100 `
+                  : `-translate-y-2 opacity-0 `
+              )}
+              style={{
+                transitionDelay: `${index * 50}ms `,
+              }}
+            >
+              <span>{option.label}</span>
+              <div
+                className={cn(
+                  "w-3 h-3 rounded-full bg-slate-800 shadow-md",
+                  optionDotVariant[option.value]
+                )}
+              ></div>
+            </li>
+          ))}
+        </ul>,
+        document.body
+      )}
+    </div>
+  );
+};

--- a/src/components/shared/DashboardTaskForm.tsx
+++ b/src/components/shared/DashboardTaskForm.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentPropsWithoutRef } from "react";
 import { Input } from "../ui/input";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 import { z } from "zod";
@@ -8,16 +8,28 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useDashboardStore } from "@/store/DashboardStore";
 import { Priority } from "@/types/taskType";
 import { v4 } from "uuid";
+import { ArrowUp } from "lucide-react";
+import { CustomSelect } from "./CustomSelect";
 
 type Form = {
   description: string;
+  priority: Priority;
 };
+const PrioritySchema = z.nativeEnum(Priority);
+
 interface DashboardTaskFormProps extends ComponentPropsWithoutRef<"form"> {}
+
+const options = [
+  { value: Priority.Low, label: "Low" },
+  { value: Priority.Medium, label: "Medium" },
+  { value: Priority.High, label: "High" },
+];
 
 const formSchema = z.object({
   description: z
     .string()
     .min(3, { message: "Description must contain at least 3 character(s)" }),
+  priority: PrioritySchema,
 });
 
 export const DashboardTaskForm = React.forwardRef<
@@ -26,15 +38,26 @@ export const DashboardTaskForm = React.forwardRef<
 >(({ className, ...props }, ref) => {
   const sectionId = useDashboardStore((state) => state.sections)[0].id;
   const addTaskToSection = useDashboardStore((state) => state.addTaskToSection);
-  const { register, handleSubmit, formState, reset } = useForm<Form>({
-    defaultValues: {
-      description: "",
-    },
-    resolver: zodResolver(formSchema),
-  });
+  const { register, handleSubmit, formState, reset, control, setValue } =
+    useForm<Form>({
+      defaultValues: {
+        description: "",
+        priority: Priority.Low,
+      },
+      resolver: zodResolver(formSchema),
+    });
+  const selectedValue = useWatch({ control: control, name: "priority" });
   const onSubmit = (data: Form) => {
-    addTaskToSection({ id: v4(), ...data, priority: Priority.Low }, sectionId);
+    addTaskToSection({ id: v4(), ...data }, sectionId);
     reset();
+  };
+  const onSelectChange = (value: unknown) => {
+    try {
+      const validatedValue = PrioritySchema.parse(value);
+      setValue("priority", validatedValue);
+    } catch (error) {
+      console.log(error);
+    }
   };
   const { errors, isSubmitting } = formState;
   return (
@@ -51,6 +74,12 @@ export const DashboardTaskForm = React.forwardRef<
           label="Description"
           {...register("description")}
           errorMessage={errors.description?.message}
+        />
+        <CustomSelect
+          options={options}
+          onChange={onSelectChange}
+          defaultValue={selectedValue}
+          icon={<ArrowUp />}
         />
         <Button disabled={isSubmitting} type="submit">
           Add Task

--- a/src/components/shared/Select.tsx
+++ b/src/components/shared/Select.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+import { ClassValue } from "clsx";
+import React from "react";
+
+interface SelectProps extends React.ComponentPropsWithoutRef<"select"> {
+  label?: string;
+  labelStyles?: ClassValue;
+}
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ label, labelStyles, className, children, ...props }, ref) => {
+    return (
+      <>
+        {label && <label className={cn("", labelStyles)}>{label}</label>}
+        <select className={cn("p-2 rounded", className)} ref={ref} {...props}>
+          {children}
+        </select>
+      </>
+    );
+  }
+);

--- a/src/types/taskType.ts
+++ b/src/types/taskType.ts
@@ -8,6 +8,11 @@ export enum TaskPosition {
   Before = "Before",
 }
 
+export type OptionType = {
+  value: Priority;
+  label: string;
+};
+
 export interface TaskType {
   id: string;
   description: string;


### PR DESCRIPTION
Created custom select and itegrated it with react-hook-forms, using setValue and useWatch hook from reac-hook-forms. useWatch hook differs from simple watch in that it doesn't cause rerenders every time we change priority. 
![image](https://github.com/user-attachments/assets/8dd8c8b5-9119-464b-9dbf-0101e273c38f)
Also added some animation on open/close and put all options into portal so select will not be overlapped by other components. 
